### PR TITLE
ACTIVITI-1991 Task is not updated in Query

### DIFF
--- a/activiti-api-task-runtime/src/main/java/org/activiti/api/task/runtime/events/TaskUpdatedEvent.java
+++ b/activiti-api-task-runtime/src/main/java/org/activiti/api/task/runtime/events/TaskUpdatedEvent.java
@@ -14,30 +14,11 @@
  * limitations under the License.
  */
 
-package org.activiti.api.task.model.events;
+package org.activiti.api.task.runtime.events;
 
-import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.task.model.Task;
+import org.activiti.api.task.model.events.TaskRuntimeEvent;
 
-
-public interface TaskRuntimeEvent<T extends Task> extends RuntimeEvent<T, TaskRuntimeEvent.TaskEvents> {
-
-    enum TaskEvents {
-
-        TASK_ASSIGNED,
-
-        TASK_COMPLETED,
-
-        TASK_CREATED,
-
-        TASK_UPDATED,
-
-        TASK_ACTIVATED,
-
-        TASK_SUSPENDED,
-
-        TASK_CANCELLED
-
-    }
+public interface TaskUpdatedEvent extends TaskRuntimeEvent<Task> {
 
 }


### PR DESCRIPTION
- created task update event in the api
- added a new value TASK_UPDATE for task events

refs [1991](https://github.com/Activiti/Activiti/issues/1991)