### PR TITLE
feat: add process runtime context attributes in RuntimeEvent api

### DIFF
--- a/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/RuntimeEventImpl.java
+++ b/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/RuntimeEventImpl.java
@@ -25,10 +25,10 @@ public abstract class RuntimeEventImpl<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> 
     private String id;
     private Long timestamp;
     private String processDefinitionId;
-	private String processDefinitionKey;
-	private Integer processDefinitionVersion;
+    private String processDefinitionKey;
+    private Integer processDefinitionVersion;
     private String businessKey;
-    
+
     private ENTITY_TYPE entity;
 
     public RuntimeEventImpl() {
@@ -63,40 +63,40 @@ public abstract class RuntimeEventImpl<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> 
     public Long getTimestamp() {
         return timestamp;
     }
-    
-    @Override
-    public String getProcessDefinitionId() {
-		return processDefinitionId;
-	}
 
     @Override
-	public String getProcessDefinitionKey() {
-		return processDefinitionKey;
-	}
+    public String getProcessDefinitionId() {
+        return processDefinitionId;
+    }
+
+    @Override
+    public String getProcessDefinitionKey() {
+        return processDefinitionKey;
+    }
 
     @Override
     public Integer getProcessDefinitionVersion() {
         return processDefinitionVersion;
     }
-    
-    @Override
-	public String getBusinessKey() {
-		return businessKey;
-	}
-    
-	public void setProcessDefinitionId(String processDefinitionId) {
-		this.processDefinitionId = processDefinitionId;
-	}
 
-	public void setProcessDefinitionKey(String processDefinitionKey) {
-		this.processDefinitionKey = processDefinitionKey;
-	}
+    @Override
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setProcessDefinitionId(String processDefinitionId) {
+        this.processDefinitionId = processDefinitionId;
+    }
+
+    public void setProcessDefinitionKey(String processDefinitionKey) {
+        this.processDefinitionKey = processDefinitionKey;
+    }
 
     public void setProcessDefinitionVersion(Integer processDefinitionVersion) {
         this.processDefinitionVersion = processDefinitionVersion;
     }
-	
-	public void setBusinessKey(String businessKey) {
-		this.businessKey = businessKey;
-	}
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
+    }
 }

--- a/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/RuntimeEventImpl.java
+++ b/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/RuntimeEventImpl.java
@@ -24,7 +24,11 @@ public abstract class RuntimeEventImpl<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> 
 
     private String id;
     private Long timestamp;
-
+    private String processDefinitionId;
+	private String processDefinitionKey;
+	private Integer processDefinitionVersion;
+    private String businessKey;
+    
     private ENTITY_TYPE entity;
 
     public RuntimeEventImpl() {
@@ -59,4 +63,40 @@ public abstract class RuntimeEventImpl<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> 
     public Long getTimestamp() {
         return timestamp;
     }
+    
+    @Override
+    public String getProcessDefinitionId() {
+		return processDefinitionId;
+	}
+
+    @Override
+	public String getProcessDefinitionKey() {
+		return processDefinitionKey;
+	}
+
+    @Override
+    public Integer getProcessDefinitionVersion() {
+        return processDefinitionVersion;
+    }
+    
+    @Override
+	public String getBusinessKey() {
+		return businessKey;
+	}
+    
+	public void setProcessDefinitionId(String processDefinitionId) {
+		this.processDefinitionId = processDefinitionId;
+	}
+
+	public void setProcessDefinitionKey(String processDefinitionKey) {
+		this.processDefinitionKey = processDefinitionKey;
+	}
+
+    public void setProcessDefinitionVersion(Integer processDefinitionVersion) {
+        this.processDefinitionVersion = processDefinitionVersion;
+    }
+	
+	public void setBusinessKey(String businessKey) {
+		this.businessKey = businessKey;
+	}
 }

--- a/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/event/RuntimeEvent.java
+++ b/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/event/RuntimeEvent.java
@@ -25,5 +25,13 @@ public interface RuntimeEvent<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> {
     Long getTimestamp();
 
     EVENT_TYPE getEventType();
+    
+    String getProcessDefinitionId();
+    
+    String getProcessDefinitionKey();
+
+    Integer getProcessDefinitionVersion();
+    
+    String getBusinessKey();
 
 }

--- a/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/IntegrationContextImpl.java
+++ b/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/IntegrationContextImpl.java
@@ -29,6 +29,9 @@ public class IntegrationContextImpl implements IntegrationContext {
     private Map<String, Object> outBoundVariables = new HashMap<>();
     private String processInstanceId;
     private String processDefinitionId;
+    private String processDefinitionKey;
+    private Integer processDefinitionVersion;
+    private String businessKey;
     private String activityElementId;
     private String connectorType;
 
@@ -100,10 +103,36 @@ public class IntegrationContextImpl implements IntegrationContext {
                                     Object value) {
         outBoundVariables.put(name, value);
     }
-
     @Override
     public void addOutBoundVariables(Map<String, Object> variables) {
         outBoundVariables.putAll(variables);
+    }
+    
+    @Override
+    public String getProcessDefinitionKey() {
+        return processDefinitionKey;
+    }
+    
+    public void setProcessDefinitionKey(String processDefinitionKey) {
+        this.processDefinitionKey = processDefinitionKey;
+    }
+    
+    @Override
+    public Integer getProcessDefinitionVersion() {
+        return processDefinitionVersion;
+    }
+
+    public void setProcessDefinitionVersion(Integer processDefinitionVersion) {
+        this.processDefinitionVersion = processDefinitionVersion;
+    }
+    
+    @Override
+    public String getBusinessKey() { 
+        return businessKey;
+    }
+    
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
     }
 
 }

--- a/activiti-api-process-model/src/main/java/org/activiti/api/process/model/IntegrationContext.java
+++ b/activiti-api-process-model/src/main/java/org/activiti/api/process/model/IntegrationContext.java
@@ -26,6 +26,12 @@ public interface IntegrationContext {
 
     String getProcessDefinitionId();
 
+    String getProcessDefinitionKey();
+
+    Integer getProcessDefinitionVersion();
+    
+    String getBusinessKey();
+    
     String getConnectorType();
 
     String getActivityElementId();


### PR DESCRIPTION
This PR proposes to  fix Activiti/Activiti#2069 by adding important process run-time context attributes such as `processDefinitionId`, `processDefinitionKey`, `processDefinitionVersion`, `businessKey` in order to enable consumers to apply event correlation with business context for `RuntimeEvent` and `IntegrationContext`.

The provided setters in `RuntimeEventImpl` and `IntegrationContextImpl` classes will allow to inject process runtime context attributes in runtime bundle events aggregator and converter modules.

We need to review and discuss if there are any additional attributes can be useful for downstream consumption such as `deploymentId`, `processName`, `superProcessInstanceId`, `superProcessInstanceName`. These attributes can be injected as message headers by events aggregator.

The implementation is non-invasive by keeping the existing class constructors intact, which makes events mutable. The best practice is to make event instances immutable to avoid any potential side effects later. We need to discuss pros and cons of the approach...