### PR TITLE
fix: add missing processInstanceId in RuntimeEvent api

### DIFF
--- a/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/RuntimeEventImpl.java
+++ b/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/RuntimeEventImpl.java
@@ -24,6 +24,7 @@ public abstract class RuntimeEventImpl<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> 
 
     private String id;
     private Long timestamp;
+    private String processInstanceId;
     private String processDefinitionId;
     private String processDefinitionKey;
     private Integer processDefinitionVersion;
@@ -65,6 +66,11 @@ public abstract class RuntimeEventImpl<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> 
     }
 
     @Override
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+    
+    @Override
     public String getProcessDefinitionId() {
         return processDefinitionId;
     }
@@ -98,5 +104,9 @@ public abstract class RuntimeEventImpl<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> 
 
     public void setBusinessKey(String businessKey) {
         this.businessKey = businessKey;
+    }
+
+    public void setProcessInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
     }
 }

--- a/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/event/RuntimeEvent.java
+++ b/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/event/RuntimeEvent.java
@@ -25,6 +25,8 @@ public interface RuntimeEvent<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> {
     Long getTimestamp();
 
     EVENT_TYPE getEventType();
+
+    String getProcessInstanceId();
     
     String getProcessDefinitionId();
     


### PR DESCRIPTION
This PR adds missing `processInstanceId` attribute in `RuntimeEvent` interface and `RuntimeEventImpl`

This is useful to correlate events to be able to issue commands with processInstanceId from any RuntimeEvent similar to IntegrationContext which has processInstanceId attribute. 

Fixes Activiti/Activiti#2069