### PR TITLE
fix: (updatebot) push version into activiti-core via single pr

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -7,3 +7,6 @@ github:
       useSinglePullRequest: true 
     - name: activiti-core-common
       branch: develop
+    - name: activiti
+      branch: develop
+      useSinglePullRequest: true 

--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -7,6 +7,7 @@ github:
       useSinglePullRequest: true 
     - name: activiti-core-common
       branch: develop
+      useSinglePullRequest: true 
     - name: activiti
       branch: develop
       useSinglePullRequest: true 

--- a/activiti-api-dependencies-tests/pom.xml
+++ b/activiti-api-dependencies-tests/pom.xml
@@ -1,0 +1,122 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.activiti.api</groupId>
+    <artifactId>activiti-api</artifactId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>activiti-api-dependencies-tests</artifactId>
+  <packaging>pom</packaging>
+  
+  <name>Activiti API :: Dependencies BOM (Bill Of Materials) Tests</name>
+  
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+  <!-- Import managed dependencies from activiti-build with SB dependency management -->
+  <!-- as we only need to enforce dependencies between Activiti modules-->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.activiti.build</groupId>
+        <artifactId>activiti-dependencies-parent</artifactId>
+        <version>${activiti-build.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>  
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-model-shared</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-runtime-shared</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-process-model</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-process-runtime</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-task-model</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-task-runtime</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-model-shared-impl</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-process-model-impl</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-task-model-impl</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>enforce-dependency-convergence</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <fail>true</fail>
+              <rules>
+                <reactorModuleConvergence>
+                  <message>The reactor is not valid</message>
+                  <ignoreModuleDependencies>false</ignoreModuleDependencies>
+                </reactorModuleConvergence>              
+                <dependencyConvergence/>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- disable parent execution which fails here -->
+            <id>enforce-plugin-versions</id>
+            <configuration>
+              <fail>false</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/activiti-api-dependencies-tests/pom.xml
+++ b/activiti-api-dependencies-tests/pom.xml
@@ -12,6 +12,7 @@
   
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <enforceFail>true</enforceFail>    
   </properties>
   <!-- Import managed dependencies from activiti-build with SB dependency management -->
   <!-- as we only need to enforce dependencies between Activiti modules-->
@@ -97,7 +98,7 @@
               <goal>enforce</goal>
             </goals>
             <configuration>
-              <fail>true</fail>
+              <fail>${enforceFail}</fail>
               <rules>
                 <reactorModuleConvergence>
                   <message>The reactor is not valid</message>

--- a/activiti-api-dependencies/pom.xml
+++ b/activiti-api-dependencies/pom.xml
@@ -29,6 +29,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.activiti.build</groupId>
+        <artifactId>activiti-dependencies-parent</artifactId>
+        <version>${activiti-build.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.activiti.api</groupId>
         <artifactId>activiti-api-model-shared</artifactId>
         <version>${activiti-api.version}</version>

--- a/activiti-api-model-shared-impl/pom.xml
+++ b/activiti-api-model-shared-impl/pom.xml
@@ -20,8 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-model-shared-impl</artifactId>
   <name>Activiti API :: Common Model Implementation</name>

--- a/activiti-api-model-shared/pom.xml
+++ b/activiti-api-model-shared/pom.xml
@@ -20,8 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-model-shared</artifactId>
   <name>Activiti API :: Model Common</name>

--- a/activiti-api-process-model-impl/pom.xml
+++ b/activiti-api-process-model-impl/pom.xml
@@ -20,8 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-process-model-impl</artifactId>
   <name>Activiti API :: Process Model Implementation</name>

--- a/activiti-api-process-model/pom.xml
+++ b/activiti-api-process-model/pom.xml
@@ -20,8 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-process-model</artifactId>
   <name>Activiti API :: Process Model API</name>

--- a/activiti-api-process-runtime/pom.xml
+++ b/activiti-api-process-runtime/pom.xml
@@ -4,8 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-process-runtime</artifactId>
   <name>Activiti API :: Process Runtime</name>

--- a/activiti-api-runtime-shared/pom.xml
+++ b/activiti-api-runtime-shared/pom.xml
@@ -4,8 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-runtime-shared</artifactId>
   <name>Activiti API :: Runtime Common</name>

--- a/activiti-api-task-model-impl/pom.xml
+++ b/activiti-api-task-model-impl/pom.xml
@@ -4,8 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-task-model-impl</artifactId>
   <name>Activiti API :: Task Model Implementation</name>

--- a/activiti-api-task-model/pom.xml
+++ b/activiti-api-task-model/pom.xml
@@ -20,8 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-task-model</artifactId>
   <name>Activiti API :: Task Model</name>

--- a/activiti-api-task-runtime/pom.xml
+++ b/activiti-api-task-runtime/pom.xml
@@ -4,8 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti.api</groupId>
-    <artifactId>activiti-api</artifactId>
+    <artifactId>activiti-api-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-api-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-task-runtime</artifactId>
   <name>Activiti API :: Task Runtime</name>

--- a/pom.xml
+++ b/pom.xml
@@ -14,64 +14,9 @@
 
   <name>Activiti API :: Parent</name>
   <packaging>pom</packaging>
-  <dependencyManagement>
-    <!-- This duplicates activiti-api-dependencies module but we can't import that module here as this is its parent-->
-    <dependencies>
-      <dependency>
-        <groupId>org.activiti.build</groupId>
-        <artifactId>activiti-dependencies-parent</artifactId>
-        <version>${activiti-build.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-model-shared</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-model-shared-impl</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-runtime-shared</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-process-model</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-process-model-impl</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-process-runtime</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-task-model</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-task-model-impl</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-task-runtime</artifactId>
-        <version>${activiti-api.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+  
   <modules>
+    <module>activiti-api-dependencies-tests</module>
     <module>activiti-api-dependencies</module>
     <module>activiti-api-model-shared</module>
     <module>activiti-api-runtime-shared</module>
@@ -104,6 +49,17 @@
     <activiti-api.version>${project.version}</activiti-api.version>
     <activiti-build.version>7.0.41</activiti-build.version> 
   </properties>
+
+  <!-- Activiti build parent marker dependency for dependency convergence tests -->
+  <dependencies>
+    <dependency>
+      <groupId>org.activiti.build</groupId>
+      <artifactId>activiti-parent</artifactId>
+      <version>${activiti-build.version}</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+  
   <build>
     <plugins>
       <plugin>
@@ -127,7 +83,7 @@
           <deployAtEnd>true</deployAtEnd>
         </configuration>
       </plugin>
-    
+      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version></plugin>
+        <version>2.8.2</version>
+        <configuration>
+          <deployAtEnd>true</deployAtEnd>
+        </configuration>
+      </plugin>
     
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR add dependency convergence tests for the same parent version and changes updatebot configuration to push version into all downstream repos via single pull request in order to enforce same parent version dependencies (Part of Activiti/Activiti#2200 and Activiti/Activiti#2198)

Also fixes Maven-deploy-plugin configuration to follow best practice for deploying multi-module project at the end. (See  Activiti/Activiti#2172)