### PR TITLE
TaskStatus extended to unify checking of task completion 

### DIFF
--- a/activiti-api-task-model/src/main/java/org/activiti/api/task/model/Task.java
+++ b/activiti-api-task-model/src/main/java/org/activiti/api/task/model/Task.java
@@ -21,12 +21,22 @@ import java.util.Date;
 public interface Task {
 
     enum TaskStatus {
-        CREATED,
-        ASSIGNED,
-        SUSPENDED,
-        COMPLETED,
-        CANCELLED,
-        DELETED
+        CREATED(false),
+        ASSIGNED(false),
+        SUSPENDED(false),
+        COMPLETED(true),
+        CANCELLED(true),
+        DELETED(true);
+
+        private final boolean finalState;
+
+        TaskStatus(boolean finalState) {
+            this.finalState = finalState;
+        }
+
+        public boolean isFinalState() {
+            return finalState;
+        }
     }
 
     String getId();


### PR DESCRIPTION
Now each TaskStatus can tell if it's a final state or not. `CREATED`, `ASSIGNED` and `SUSPENDED` **are not final**; `COMPLETED`, `CANCELLED`, `DELETED` **are final**.
Related to 
https://github.com/Activiti/Activiti/issues/2669
https://github.com/Activiti/Activiti/issues/2724