### PR TITLE
ProcessInstanceStatus extended to check that processInstance is ended

### DIFF
--- a/activiti-api-process-model/src/main/java/org/activiti/api/process/model/ProcessInstance.java
+++ b/activiti-api-process-model/src/main/java/org/activiti/api/process/model/ProcessInstance.java
@@ -21,12 +21,22 @@ import java.util.Date;
 public interface ProcessInstance {
 
     enum ProcessInstanceStatus {
-        CREATED,
-        RUNNING,
-        SUSPENDED,
-        CANCELLED,
-        COMPLETED,
-        DELETED
+        CREATED(false),
+        RUNNING(false),
+        SUSPENDED(false),
+        CANCELLED(true),
+        COMPLETED(true),
+        DELETED(true);
+
+        private final boolean finalState;
+
+        ProcessInstanceStatus(boolean finalState) {
+            this.finalState = finalState;
+        }
+
+        public boolean isFinalState() {
+            return finalState;
+        }
     }
 
     String getId();


### PR DESCRIPTION
Related to https://github.com/Activiti/Activiti/issues/2724
Now each ProcessInstanceStatus can tell if it's a final state or not. CREATED, RUNNING and SUSPENDED are not final; COMPLETED, CANCELLED, DELETED are final.