### PR TITLE
fix(AAE-201): Extended SecurityManager with authenticated principal user groups and roles Api

### DIFF
--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/AbstractSecurityManager.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/AbstractSecurityManager.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.api.runtime.shared.security;
+
+import java.util.List;
+
+public abstract class AbstractSecurityManager implements SecurityManager {
+    
+    private static final String INVALID_AUTHENTICATED_PRINCIPAL = "Invalid authenticated principal";
+
+    private final SecurityContextPrincipalProvider securityContextPrincipalProvider;
+    private final PrincipalIdentityProvider principalIdentityProvider;
+    private final PrincipalDetailsProvider principalDetailsProvider;
+
+    public AbstractSecurityManager(SecurityContextPrincipalProvider securityContextPrincipalProvider,
+                                   PrincipalIdentityProvider principalIdentityProvider,
+                                   PrincipalDetailsProvider principalDetailsProvider) {
+        this.securityContextPrincipalProvider = securityContextPrincipalProvider;
+        this.principalIdentityProvider = principalIdentityProvider;
+        this.principalDetailsProvider = principalDetailsProvider;
+    }
+
+    @Override
+    public String getAuthenticatedUserId() {
+        return securityContextPrincipalProvider.getCurrentPrincipal()
+                                               .map(principalIdentityProvider::getUserId)
+                                               .orElseThrow(this::securityException);
+    }
+
+    @Override
+    public List<String> getAuthenticatedUserGroups() {
+        return securityContextPrincipalProvider.getCurrentPrincipal()
+                                               .map(principalDetailsProvider::getGroups)
+                                               .orElseThrow(this::securityException);
+    }
+
+    @Override
+    public List<String> getAuthenticatedUserRoles() {
+        return securityContextPrincipalProvider.getCurrentPrincipal()
+                                               .map(principalDetailsProvider::getRoles)
+                                               .orElseThrow(this::securityException);
+    }
+    
+    protected SecurityException securityException() {
+        return new SecurityException(INVALID_AUTHENTICATED_PRINCIPAL);
+    }
+    
+}

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/AbstractSecurityManager.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/AbstractSecurityManager.java
@@ -24,14 +24,17 @@ public abstract class AbstractSecurityManager implements SecurityManager {
 
     private final SecurityContextPrincipalProvider securityContextPrincipalProvider;
     private final PrincipalIdentityProvider principalIdentityProvider;
-    private final PrincipalDetailsProvider principalDetailsProvider;
+    private final PrincipalGroupsProvider principalGroupsProvider;
+    private final PrincipalRolesProvider principalRolesProvider;
 
     public AbstractSecurityManager(SecurityContextPrincipalProvider securityContextPrincipalProvider,
                                    PrincipalIdentityProvider principalIdentityProvider,
-                                   PrincipalDetailsProvider principalDetailsProvider) {
+                                   PrincipalGroupsProvider principalGroupsProvider,
+                                   PrincipalRolesProvider principalRolesProvider) {
         this.securityContextPrincipalProvider = securityContextPrincipalProvider;
         this.principalIdentityProvider = principalIdentityProvider;
-        this.principalDetailsProvider = principalDetailsProvider;
+        this.principalGroupsProvider = principalGroupsProvider;
+        this.principalRolesProvider = principalRolesProvider;
     }
 
     @Override
@@ -44,14 +47,14 @@ public abstract class AbstractSecurityManager implements SecurityManager {
     @Override
     public List<String> getAuthenticatedUserGroups() {
         return securityContextPrincipalProvider.getCurrentPrincipal()
-                                               .map(principalDetailsProvider::getGroups)
+                                               .map(principalGroupsProvider::getGroups)
                                                .orElseThrow(this::securityException);
     }
 
     @Override
     public List<String> getAuthenticatedUserRoles() {
         return securityContextPrincipalProvider.getCurrentPrincipal()
-                                               .map(principalDetailsProvider::getRoles)
+                                               .map(principalRolesProvider::getRoles)
                                                .orElseThrow(this::securityException);
     }
     

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalDetailsProvider.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalDetailsProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.api.runtime.shared.security;
+
+import java.security.Principal;
+import java.util.List;
+
+public interface PrincipalDetailsProvider {
+    
+    List<String> getGroups(Principal principal);
+    
+    List<String> getRoles(Principal principal);
+}

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalGroupsProvider.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalGroupsProvider.java
@@ -19,9 +19,8 @@ package org.activiti.api.runtime.shared.security;
 import java.security.Principal;
 import java.util.List;
 
-public interface PrincipalDetailsProvider {
+public interface PrincipalGroupsProvider {
     
-    List<String> getGroups(Principal principal);
-    
-    List<String> getRoles(Principal principal);
+   List<String> getGroups(Principal principal);
+
 }

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalIdentityProvider.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalIdentityProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.api.runtime.shared.security;
+
+import java.security.Principal;
+
+public interface PrincipalIdentityProvider {
+    
+    default String getUserId(Principal principal) {
+        return principal.getName();
+    };
+
+}

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalIdentityProvider.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalIdentityProvider.java
@@ -17,11 +17,14 @@
 package org.activiti.api.runtime.shared.security;
 
 import java.security.Principal;
+import java.util.Optional;
 
 public interface PrincipalIdentityProvider {
     
     default String getUserId(Principal principal) {
-        return principal.getName();
+        return Optional.of(principal)
+                       .map(Principal::getName)
+                       .orElseThrow(() -> new SecurityException("Invalid security principal name"));
     };
 
 }

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalRolesProvider.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/PrincipalRolesProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.api.runtime.shared.security;
+
+import java.security.Principal;
+import java.util.List;
+
+public interface PrincipalRolesProvider {
+    
+    List<String> getRoles(Principal principal);
+
+}

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityContextPrincipalProvider.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityContextPrincipalProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.api.runtime.shared.security;
+
+import java.security.Principal;
+import java.util.Optional;
+
+public interface SecurityContextPrincipalProvider {
+    
+    Optional<Principal> getCurrentPrincipal();
+    
+}

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityManager.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityManager.java
@@ -1,7 +1,14 @@
 package org.activiti.api.runtime.shared.security;
 
+import java.util.Collections;
+import java.util.List;
+
 public interface SecurityManager {
 
     String getAuthenticatedUserId();
+    
+    default List<String> getAuthenticatedUserGroups() {
+        return Collections.emptyList();
+    }
 
 }

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityManager.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityManager.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.activiti.api.runtime.shared.security;
 
-import java.util.Collection;
+import java.util.List;
 
 public interface SecurityManager {
 
@@ -13,21 +29,21 @@ public interface SecurityManager {
     String getAuthenticatedUserId();
     
     /**
-     * Get currently authenticated user group names from application security context 
+     * Get group names for currently authenticated user from application security context 
      * 
      * @return list of group names the current user is member of
      * 
-     * @throws SecurityException if principal security context does not exists.
+     * @throws SecurityException if principal security context is not valid
      */
-    Collection<String> getAuthenticatedUserGroups() throws SecurityException;
+    List<String> getAuthenticatedUserGroups() throws SecurityException;
     
     /**
-     * Get currently authenticated user list of role names from application security context 
+     * Get list of role names for currently authenticated user from application security context 
      * 
      * @return list of roles names or empty collection
      * 
-     * @throws SecurityException if principal security context does not exists.
+     * @throws SecurityException if principal security context is not valid
      */
-    Collection<String> getAuthenticatedUserRoles() throws SecurityException;
+    List<String> getAuthenticatedUserRoles() throws SecurityException;
 
 }

--- a/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityManager.java
+++ b/activiti-api-runtime-shared/src/main/java/org/activiti/api/runtime/shared/security/SecurityManager.java
@@ -1,14 +1,33 @@
 package org.activiti.api.runtime.shared.security;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Collection;
 
 public interface SecurityManager {
 
+    /**
+     * Get currently authenticated user id from application security context  
+     * 
+     * @return currently authenticate user id or empty string if anonymous user
+     * 
+     */
     String getAuthenticatedUserId();
     
-    default List<String> getAuthenticatedUserGroups() {
-        return Collections.emptyList();
-    }
+    /**
+     * Get currently authenticated user group names from application security context 
+     * 
+     * @return list of group names the current user is member of
+     * 
+     * @throws SecurityException if principal security context does not exists.
+     */
+    Collection<String> getAuthenticatedUserGroups() throws SecurityException;
+    
+    /**
+     * Get currently authenticated user list of role names from application security context 
+     * 
+     * @return list of roles names or empty collection
+     * 
+     * @throws SecurityException if principal security context does not exists.
+     */
+    Collection<String> getAuthenticatedUserRoles() throws SecurityException;
 
 }


### PR DESCRIPTION
This PR extends SecurityManager Api to support retrieving authenticated principal user groups and roles from application security context.

Part of https://github.com/Activiti/Activiti/issues/2765