### PR TITLE
refactor(build): changed spring-boot-autoconfigure module to be optional

### DIFF
--- a/activiti-api-process-model-impl/pom.xml
+++ b/activiti-api-process-model-impl/pom.xml
@@ -58,6 +58,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/activiti-api-task-model-impl/pom.xml
+++ b/activiti-api-task-model-impl/pom.xml
@@ -42,6 +42,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This PR has changed spring-boot-autoconfigure module to be optional dependency in order not to bundle it with library modules. 

Part of https://github.com/Activiti/Activiti/pull/2904

Fixes https://github.com/Activiti/Activiti/issues/1399