### PR TITLE
fix(AAE-896): Added Serializable support to api models 

### DIFF
--- a/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/Payload.java
+++ b/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/Payload.java
@@ -1,5 +1,7 @@
 package org.activiti.api.model.shared;
 
-public interface Payload {
+import java.io.Serializable;
+
+public interface Payload extends Serializable {
     String getId();
 }

--- a/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/Result.java
+++ b/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/Result.java
@@ -1,6 +1,10 @@
 package org.activiti.api.model.shared;
 
-public abstract class Result<T> {
+import java.io.Serializable;
+
+public abstract class Result<T> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private Payload payload;
     private T entity;

--- a/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/event/RuntimeEvent.java
+++ b/activiti-api-model-shared/src/main/java/org/activiti/api/model/shared/event/RuntimeEvent.java
@@ -16,7 +16,9 @@
 
 package org.activiti.api.model.shared.event;
 
-public interface RuntimeEvent<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> {
+import java.io.Serializable;
+
+public interface RuntimeEvent<ENTITY_TYPE, EVENT_TYPE extends Enum<?>> extends Serializable {
 
     String getId();
 


### PR DESCRIPTION
This PR adds Java `Serializable` support to api models. This is required for JDBC message  group store backend